### PR TITLE
New InfoWindows in maps

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@
 							  position: tgz,
 							  map: map
 							});
-						  	var contentString = '<b>Turnerschaft Gotia Zaringia</b><br>Durlacher Allee 13<br>76131 Karlsruhe<br>Deutschland<br><a href="https://goo.gl/maps/wT2jZ4vcmNTJS6SEA">In Google Maps ansehen</a>';
+						  	var contentString = '<b>Turnerschaft Gotia-Zaringia im CC</b><br>Durlacher Allee 13<br>76131 Karlsruhe<br>Deutschland<br><a href="https://goo.gl/maps/wT2jZ4vcmNTJS6SEA">In Google Maps ansehen</a>';
 
 							var infowindow = new google.maps.InfoWindow({content: contentString});
 							google.maps.event.addListener(marker, "click", function(){infowindow.open(map,marker);});infowindow.open(map,marker);

--- a/index.html
+++ b/index.html
@@ -272,7 +272,9 @@
 							  position: tgz,
 							  map: map
 							});
-							var infowindow = new google.maps.InfoWindow({content: "<b>Turnerschaft Gotia Zaringia</b><br>Durlacher Allee 13<br>76131 Karlsruhe"});
+						  	var contentString = '<b>Turnerschaft Gotia Zaringia</b><br>Durlacher Allee 13<br>76131 Karlsruhe<br>Deutschland<br><a href="https://goo.gl/maps/wT2jZ4vcmNTJS6SEA">In Google Maps ansehen</a>';
+
+							var infowindow = new google.maps.InfoWindow({content: contentString});
 							google.maps.event.addListener(marker, "click", function(){infowindow.open(map,marker);});infowindow.open(map,marker);
 						  }
 						</script>


### PR DESCRIPTION
Ohne Style, nur mit zusätzlicher Verlinkung zur Google-Seite von der TGZ.
Evtl könnte man da zusätzlich noch verschiedene Schriftgrößen für die Überschrift einbauen, da sie aktuell etwas kleiner ist als die Überschrift der standard InfoWindows.
closes #16 